### PR TITLE
Add the optional ability to view shorthand forms of cards/items in c!inventory and c!shop using "-s"

### DIFF
--- a/commands/inventory.lua
+++ b/commands/inventory.lua
@@ -3,10 +3,24 @@ function command.run(message, mt)
   print(message.author.name .. " did !inventory")
   local uj = dpf.loadjson("savedata/" .. message.author.id .. ".json",defaultjson)
 
+  local enableShortNames = false
+
   local pagenumber = 1
-  if tonumber(mt[1]) then
-    pagenumber = math.floor(mt[1])
+
+  args = {}
+  for substring in mt[1]:gmatch("%S+") do
+    table.insert(args, substring)
   end
+
+  for index, value in ipairs(args) do
+    if tonumber(value) then
+      pagenumber = math.floor(tonumber(value))
+    end
+    if value == "-s" then
+      enableShortNames = true
+    end
+  end
+
   pagenumber = math.max(1, pagenumber)
 
   local numcards = 0
@@ -17,7 +31,11 @@ function command.run(message, mt)
 
   local invtable = {}
   local invstring = ''
-  for k,v in pairs(uj.inventory) do table.insert(invtable, "**" .. (cdb[k].name or k) .. "** x" .. v .. "\n") end
+  if enableShortNames == true then
+    for k,v in pairs(uj.inventory) do table.insert(invtable, "**" .. (cdb[k].name or k) .. "** x" .. v .. " (" .. k.. ")\n") end
+  else
+    for k,v in pairs(uj.inventory) do table.insert(invtable, "**" .. (cdb[k].name or k) .. "** x" .. v .. "\n") end
+  end
   table.sort(invtable)
 
   for i = (pagenumber - 1) * 10 + 1, (pagenumber) * 10 do

--- a/commands/look.lua
+++ b/commands/look.lua
@@ -405,21 +405,47 @@ function command.run(message, mt)
   end
   
   if uj.room == 3 then     --------------------------------------------------SHOP--------------------------------------------------------------------------   
-    
+    args = {}
+    for substring in mt[1]:gmatch("%S+") do
+      table.insert(args, substring)
+    end
       
-    local request = string.lower(mt[1]) --why tf didint i do this for all the other ones?????????????????
+    local request = string.lower(args[1]) --why tf didint i do this for all the other ones?????????????????
     if (request == "shop" or request == "quaintshop" or request == "quaint shop" or request == "")  then
       local time = sw:getTime()
       checkforreload(time:toDays())
+
+      local showShortHandForm = false
+
+      if args[#args] == "-s" then
+        showShortHandForm = true
+        table.remove(args, #args)
+      end
+
       local sj = dpf.loadjson("savedata/shop.json", defaultshopsave)
       local shopstr = ""
       for i,v in ipairs(sj.cards) do
-        shopstr = shopstr .. "\n**"..cdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock
+        if showShortHandForm == true then
+          shopstr = shopstr .. "\n**"..cdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock .. " | ("..v.name..")"
+        else
+          shopstr = shopstr .. "\n**"..cdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock
+        end
       end
       for i,v in ipairs(sj.consumables) do
-        shopstr = shopstr .. "\n**"..consdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock
+        if showShortHandForm == true then
+          shopstr = shopstr .. "\n**"..consdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock .. " | ("..v.name..")"
+        else
+          shopstr = shopstr .. "\n**"..consdb[v.name].name.."** ("..v.price.." token" .. (v.price == 1 and "" or "s") .. ") x"..v.stock
+        end
       end
-      shopstr = shopstr .. "\n**"..itemdb[sj.item].name.."** (" .. sj.itemprice .. " token" .. (sj.itemprice == 1 and "" or "s") ..") x"..sj.itemstock
+
+
+      if showShortHandForm == true then        
+        shopstr = shopstr .. "\n**"..itemdb[sj.item].name.."** (" .. sj.itemprice .. " token" .. (sj.itemprice == 1 and "" or "s") ..") x"..sj.itemstock.." | ("..sj.item..")"
+      else
+        shopstr = shopstr .. "\n**"..itemdb[sj.item].name.."** (" .. sj.itemprice .. " token" .. (sj.itemprice == 1 and "" or "s") ..") x"..sj.itemstock
+      end
+
       message.channel:send{embed = {
         color = 0x85c5ff,
         title = "Looking at Shop...",

--- a/commands/use.lua
+++ b/commands/use.lua
@@ -628,8 +628,13 @@ o-''|\\_____/)
         },"buy",{itemtype = "card",sname=sname,sprice=sprice,sindex=sindex,srequest=srequest,numrequest=numrequest})
         return
       end
-
-      sendshoperror["unknownrequest"]()
+      
+      -- for c!shop -s
+      if mt[2] == "-s" then
+        cmd.look.run(message, { "shop -s" }) 
+      else
+        sendshoperror["unknownrequest"]()
+      end
       return
     elseif request == "wolf" then
       message.channel:send{embed = {


### PR DESCRIPTION
Everything's in the name.

How to use:<br/>
- simply write `c!inventory -s` instead of `c!inventory` and the shorthand form of the cards you have will be written next to the name of these cards! 
- Also, do `c!shop -s` instead of `c!shop` to see the shorthand form of the cards being sold by the Wolf!

Could be useful to know the shorthand name of cards ~~that you completely forgot about, rotting in your inventory since last year and be able to store them easily~~

Have a preview from a private fork i made for a friend's server (that i'm using to test if the new features i'm making work well):<br/>
![image](https://user-images.githubusercontent.com/47950669/182865494-5ac6520b-584a-4f09-88aa-e708e2d40366.png)

(Side note, yes, `c!inv <page>` does work with `-s`)