### PR TITLE
Update nickname.lua

### DIFF
--- a/commands/nickname.lua
+++ b/commands/nickname.lua
@@ -30,6 +30,11 @@ function command.run(message, mt)
       message.channel:send("You cannot set your ID as a nickname!")
       return
     end
+    
+    if mt[2] == '-season' or '-s' then
+      message.channel:send("You cannot set that as a nickname!")
+      return
+    end
 
     if usernametojson(mt[2]) then
       if string.find(usernametojson(mt[2]), uj.id, 10) then


### PR DESCRIPTION
Made -season or -s not able to be set as a nickname, since it can cause confusion when c!fullinv -season or -s is made
![image](https://user-images.githubusercontent.com/47936955/183561866-372de576-dec9-4991-863f-0f56c48030ae.png)