### PR TITLE
rts item hotfix

### DIFF
--- a/commands/pull.lua
+++ b/commands/pull.lua
@@ -27,9 +27,8 @@ local time = sw:getTime()
   local maxcryopodstorage = 3
   
   
-  ----TEMP DISABLE OF FEATURE SO THE ITEM CAN BE GIVEN OUT TO PPL-----
-  if false then--uj.equipped == "sparecryopod" then
-    local missedpulls = math.floor((time:toHours() - uj.lastpull)/cooldown)-1
+  if uj.equipped == "sparecryopod" then
+    local missedpulls = math.floor((time:toHours() - math.max(uj.lastpull, uj.lastequip))/cooldown)-1
     if missedpulls > 0 then
 			--TODO: translated strings (also i really need to hurry up on implementing the upgrade to languages)
       local resultmessage = "You missed "..missedpulls.." opportunities to pull since last pull,  "


### PR DESCRIPTION
Prevents getting additional pulls when spare cryopod not equip'd
quick tweak asked by dps, now it takes when you equipped the spare cryopod into account, which completely zeros out any previous lost pulls that happened when you didn't have the item equipped.