### PR TITLE
Items/Consumables rebalancing

### DIFF
--- a/commands/pull.lua
+++ b/commands/pull.lua
@@ -29,6 +29,11 @@ local time = sw:getTime()
   end
 
   local maxcryopodstorage = 3
+
+  if math.ceil(time:toSeconds() - uj.lastpull * 3600) <= 3 then
+    message.channel:send("Please wait a bit before pulling again.")
+    return
+  end
   
   
   if uj.equipped == "sparecryopod" then

--- a/commands/reloaddb.lua
+++ b/commands/reloaddb.lua
@@ -927,7 +927,7 @@ function command.run(message, mt, overwrite)
           end
         end
 
-        newconsumables[i] = {name = nc,stock = consdb[nc].basestock + math.random(0, 4), price = consdb[nc].baseprice + math.random(-1,1)}
+        newconsumables[i] = {name = nc,stock = consdb[nc].basestock + math.random(0, 4), price = math.max(1, consdb[nc].baseprice + math.random(-1,1))}
         
       end
       sj.consumables = newconsumables

--- a/consumables/seasonbooster.lua
+++ b/consumables/seasonbooster.lua
@@ -17,9 +17,9 @@ function item.run(uj, ujf, message, mt, interaction, fn)
 
     uj.conspt = "season" .. season
     replying:reply(itemtext)
-    --[[local randtime = math.random(4, 8)
+    local randtime = math.random(4, 8)
     uj.lastpull = uj.lastpull - randtime
-    message:reply('Also, your pull cooldown was decreased by ' .. randtime .. ' hours!')]]--
+    message:reply('Also, your pull cooldown was decreased by ' .. randtime .. ' hours!')
     dpf.savejson(ujf, uj)
   else
     replying:reply(lang.seasonbooster_conspt_1 .. itemname .. lang.seasonbooster_conspt_2)

--- a/consumables/subwayticket.lua
+++ b/consumables/subwayticket.lua
@@ -11,7 +11,7 @@ function item.run(uj, ujf, message, mt, interaction)
 
     uj.conspt = "sbubby"
     replying:reply(lang.subwayticket_message)
-    local randtime = math.random(12, 24)
+    local randtime = 12 --math.random(12, 24)
     uj.lastpull = uj.lastpull - randtime
     message:reply(lang.cooldown_decrease_1 .. randtime .. lang.cooldown_decrease_2)
     dpf.savejson(ujf, uj)

--- a/data/consumables.json
+++ b/data/consumables.json
@@ -285,9 +285,8 @@
     "name": "Subway Ticket",
     "description": "The next card you pull is guaranteed. You can only use one item of this type at a time.",
     "embed": "https://cdn.discordapp.com/attachments/829197797789532181/990822635485138964/subwayticket.png",
-    "baseprice": 1,
-    "basestock": 20,
-    "quantity": 3,
+    "baseprice": 0,
+    "basestock": 8,
     "chance": 10
   },
 


### PR DESCRIPTION
### Seasonal boosters now have cooldown decrease again

Since boosters are more expensive than I expected, not having the cooldown decrease is a bit underwhelming for a consumable that costs on average 8 tokens. Re-enabling cooldowns should make them a bit more usable.

### Added a short cooldown to c!p with Spare Cryopod

Bandage fix for being able to pull too many times with Spare Cryopod. https://discord.com/channels/296802696243970049/793993844789870603/1110257626547245080

### Shop prices now have a minimum of 1 token

https://discord.com/channels/296802696243970049/793993844789870603/1110230983480979526

### Subway Ticket's price is now always 1 token, stock decreased, no longer comes in a pack of 3

Spending only 20 tokens for 60 cards should be illegal, even for a joke item

### Subway Ticket's cooldown decrease is now always 12 hours

Probably unintended effect with Spare Cryopod - if you highroll (23 or 24) you get a free normal pull